### PR TITLE
Feature: Resumable training

### DIFF
--- a/unet/train.py
+++ b/unet/train.py
@@ -3,7 +3,7 @@ import os
 
 from dataset import Carla
 from sklearn.model_selection import train_test_split
-from typing import Tuple
+from typing import Optional, Tuple
 
 
 def train_unet(
@@ -12,8 +12,13 @@ def train_unet(
         batch_size : int,
         img_size : Tuple[int, int] = (128,128),
         test_size : float = 0.25,
-        dataset_folder : str = "./dataset"
+        dataset_folder : str = "./dataset",
+        checkpoint_file : str = "./checkpoints/unet.h5",
+        load_from_checkpoint : Optional[str] = None
     ):
+
+    if load_from_checkpoint is not None:
+        model.load_weights(load_from_checkpoint)
     
     rgb_folder = f"{dataset_folder}/rgb"
     rgb_paths = sorted(
@@ -46,7 +51,7 @@ def train_unet(
     model.compile(optimizer="rmsprop", loss="sparse_categorical_crossentropy")
 
     callbacks = [
-        keras.callbacks.ModelCheckpoint("carla_segmentation.h5", save_best_only=True)
+        keras.callbacks.ModelCheckpoint(checkpoint_file, save_best_only=True)
     ]
 
     model.fit(training_generator, epochs=epochs, validation_data=validation_generator, callbacks=callbacks)

--- a/unet/train.py
+++ b/unet/train.py
@@ -53,7 +53,7 @@ def train_unet(
 
     callbacks = [
         keras.callbacks.ModelCheckpoint(f"{checkpoint_directory}/unet.h5", save_best_only=True)
-        keras.callbacks.BackupAndRestore(backup_dir="./checkpoints/")
+        keras.callbacks.BackupAndRestore(backup_dir=f"{checkpoint_directory}/")
     ]
 
     model.fit(training_generator, epochs=epochs, validation_data=validation_generator, callbacks=callbacks)

--- a/unet/train.py
+++ b/unet/train.py
@@ -5,6 +5,7 @@ from dataset import Carla
 from sklearn.model_selection import train_test_split
 from typing import Optional, Tuple
 
+from keras.models import load_model
 
 def train_unet(
         model,
@@ -13,7 +14,7 @@ def train_unet(
         img_size : Tuple[int, int] = (128,128),
         test_size : float = 0.25,
         dataset_folder : str = "./dataset",
-        checkpoint_file : str = "./checkpoints/unet.h5",
+        checkpoint_directory : str = "./checkpoints/",
         load_from_checkpoint : Optional[str] = None
     ):
 
@@ -51,7 +52,8 @@ def train_unet(
     model.compile(optimizer="rmsprop", loss="sparse_categorical_crossentropy")
 
     callbacks = [
-        keras.callbacks.ModelCheckpoint(checkpoint_file, save_best_only=True)
+        keras.callbacks.ModelCheckpoint(f"{checkpoint_directory}/unet.h5", save_best_only=True)
+        keras.callbacks.BackupAndRestore(backup_dir="./checkpoints/")
     ]
 
     model.fit(training_generator, epochs=epochs, validation_data=validation_generator, callbacks=callbacks)


### PR DESCRIPTION
This PR introduces two methods of resumable training. The first is specifying a checkpoint load point that sets the model's weights to the checkpoints. This is good for resuming training from a pretrained model to add epochs. The second is the newer `BackupAndRestore` callback functionality. If the checkpoints folder exists w/ a per epoch checkpoint, it will resume training from the left-off epoch. This also remembers the prior loss and other training specific variables.